### PR TITLE
Rollbar integration

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,6 +1,17 @@
+import Rollbar from 'rollbar'
 import { Log } from '../log'
 
 const log = new Log('Server')
+let rollbar = null
+
+/**
+ * Set up rollbar integration to report server errors raised while using {@link server#handleRequest}
+ * @param  {string} accessToken - Rollbar access token
+ */
+export function useRollbar(accessToken) {
+  if (!accessToken) return
+  rollbar = new Rollbar(accessToken)
+}
 
 /**
  * Wrapper for the request handler. It creates the appropiate response object and catches errors. For example:
@@ -24,6 +35,8 @@ export function handleRequest(callback) {
 
       const data = error.data || {}
       const message = error.message
+
+      if (rollbar) rollbar.error(error, req)
 
       return res.json(sendError(data, message))
     }


### PR DESCRIPTION
the idea is to use it like:

```javascript
import { server } from 'decentraland-commons'

if (env.isProduction()) {
 // (...)
  server.useRollbar(env.get('ROLLBAR_ACCESS_TOKEN')
}
```

and that's it!
I don't love the name `useRollbar` but I used it to adhere to the `app.use()` idea of express. Open to changes!