### PR TITLE
Support an options object as the parameter to `connect`

### DIFF
--- a/src/ethereum/README.md
+++ b/src/ethereum/README.md
@@ -31,13 +31,15 @@ class SuperTokenContract extends Contract {
 }
 
 // null is the default account here
-eth.connect([
+eth.connect({
+  contracts: [
     { name: 'ContractName', address: '0x221100', abi: [{}] },
     // or
     SuperTokenContract,
     // or
     new SuperTokenContract()
-], /* defaultAccount */)
+  ]
+})
 
 eth.fetchTxStatus('TX_HASH')
 ```


### PR DESCRIPTION
From:

```javascript
 await eth.connect(
  [LANDRegistry],
  ['0x627306090abaB3A6e1400e9345bC60c78a8BEf57'],
  {httpProviderUrl: 'https://ropsten.infura.io'}
)
```

To:


```javascript
await eth.connect({
  contracts: [LANDRegistry],
  defaultAddress: '0x627306090abaB3A6e1400e9345bC60c78a8BEf57'
  httpProviderUrl: 'https://ropsten.infura.io'
})
```

Related PR: https://github.com/decentraland/contracts/pull/8
Fix: #17 