### PR TITLE
chore: store everything on cache to fix semantic release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
 
       - save_cache:
           paths:
-            - dist
+            - "."
           key: dist-{{ .Revision }}
 
   deploy:


### PR DESCRIPTION
`semantic-release` is throwing because once the cache is restored, there's no `package.json` (cos we were only storing the `dist` folder on cache).

here's the error: https://circleci.com/gh/decentraland/commons/162