### PR TITLE
[fix] Blank ipns link

### DIFF
--- a/specs/LANDRegistry.spec.js
+++ b/specs/LANDRegistry.spec.js
@@ -159,6 +159,17 @@ has a line break`,
         }
         expect(LANDRegistry.decodeLandData(data)).to.deep.equal(expected)
       })
+
+      it('should work with a blank ipns link', function() {
+        const data = '0,"My Parcel","This is my awesome parcel",'
+        const expected = {
+          version: 0,
+          name: 'My Parcel',
+          description: 'This is my awesome parcel',
+          ipns: ''
+        }
+        expect(LANDRegistry.decodeLandData(data)).to.deep.equal(expected)
+      })
     })
   })
 })

--- a/src/contracts/LANDRegistry.js
+++ b/src/contracts/LANDRegistry.js
@@ -24,7 +24,7 @@ export class LANDRegistry extends Contract {
           // to support stuff like `0,,,ipns:link`
           name: name || '',
           description: description || '',
-          ipns
+          ipns: ipns || ''
         }
       }
       default:


### PR DESCRIPTION
Fixes bug where an empty ipns link would be decoded as `0` instead of `""`