### PR TITLE
[Fix] Contract instances

### DIFF
--- a/src/ethereum/eth.js
+++ b/src/ethereum/eth.js
@@ -108,7 +108,7 @@ export const eth = {
         contractName = contractData.getContractName()
       } else if (
         typeof contractData === 'object' &&
-        !contract.constructor !== Object
+        !contractName.constructor !== Object
       ) {
         // contractData is an instance of Contract or of one of its subclasses
         contract = contractData

--- a/src/ethereum/eth.js
+++ b/src/ethereum/eth.js
@@ -108,7 +108,7 @@ export const eth = {
         contractName = contractData.getContractName()
       } else if (
         typeof contractData === 'object' &&
-        !contractName.constructor !== Object
+        contractName.constructor !== Object
       ) {
         // contractData is an instance of Contract or of one of its subclasses
         contract = contractData


### PR DESCRIPTION
Fixed a bug when using an instance of a contract instead of the class. We were checking the wrong variable for the `constructor` and there was an extra `!` from the previous condition.