### PR TITLE
Change: peerDependencies -> devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1862,6 +1862,12 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
+    "console-polyfill": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/console-polyfill/-/console-polyfill-0.3.0.tgz",
+      "integrity": "sha512-w+JSDZS7XML43Xnwo2x5O5vxB0ID7T5BdqDtyqT6uiCAX2kZAgcWxNaGqT97tZfSHzfOcvrfsDAodKcJ3UvnXQ==",
+      "dev": true
+    },
     "conventional-changelog-angular": {
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
@@ -2073,6 +2079,16 @@
         "ms": "2.0.0"
       }
     },
+    "decache": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/decache/-/decache-3.1.0.tgz",
+      "integrity": "sha1-T1A2+9ZYH8yXI3rDlUokS5U2wto=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "find": "0.2.9"
+      }
+    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -2267,6 +2283,12 @@
         "is-obj": "1.0.1"
       }
     },
+    "dotenv": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+      "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
+      "dev": true
+    },
     "drbg.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
@@ -2384,6 +2406,15 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "requires": {
         "is-arrayish": "0.2.1"
+      }
+    },
+    "error-stack-parser": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.3.tgz",
+      "integrity": "sha1-+tpuOpzSsOCA5tb8dRQYZJc081w=",
+      "dev": true,
+      "requires": {
+        "stackframe": "0.3.1"
       }
     },
     "es-abstract": {
@@ -2649,7 +2680,7 @@
     "eth-sig-util": {
       "version": "git+https://github.com/decentraland/eth-sig-util.git#4d219a77ed6da4a9eb65e2a9f64b5929dbc09d8b",
       "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#09c3c48fd3bed143df7fa8f36f6f164205e23796",
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
         "ethereumjs-util": "5.1.5"
       }
     },
@@ -2659,7 +2690,7 @@
       "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
     },
     "ethereumjs-abi": {
-      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#09c3c48fd3bed143df7fa8f36f6f164205e23796",
+      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
       "requires": {
         "bn.js": "4.11.8",
         "ethereumjs-util": "5.1.5"
@@ -2731,9 +2762,9 @@
       }
     },
     "ethereumjs-vm": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.3.tgz",
-      "integrity": "sha512-yIWJqTEcrF9vJTCvNMxacRkAx6zIZTOW0SmSA+hSFiU1x8JyVZDi9o5udwsRVECT5RkPgQzm62kpL6Pf4qemsw==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.4.tgz",
+      "integrity": "sha512-Y4SlzNDqxrCO58jhp98HdnZVdjOqB+HC0hoU+N/DEp1aU+hFkRX/nru5F7/HkQRPIlA6aJlQp/xIA6xZs1kspw==",
       "requires": {
         "async": "2.6.0",
         "async-eventemitter": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
@@ -2927,6 +2958,16 @@
         "repeat-string": "1.6.1"
       }
     },
+    "find": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/find/-/find-0.2.9.tgz",
+      "integrity": "sha1-S3Px/55WrZG3bnFkB/5f/mVUu4w=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "traverse-chain": "0.1.0"
+      }
+    },
     "find-parent-dir": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
@@ -3043,6 +3084,15 @@
         "klaw": "1.3.1",
         "path-is-absolute": "1.0.1",
         "rimraf": "2.6.2"
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "dev": true,
+      "requires": {
+        "minipass": "2.2.4"
       }
     },
     "fs-readdir-recursive": {
@@ -4397,6 +4447,73 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
+    "inquirer": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+      "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "3.0.0",
+        "chalk": "2.3.2",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.1.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.5",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rxjs": "5.5.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
     "into-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
@@ -4671,6 +4788,12 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    },
+    "is_js": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/is_js/-/is_js-0.9.0.tgz",
+      "integrity": "sha1-CrlFQFArp6+iTIVqqYVWFmnpxS0=",
+      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -5125,6 +5248,12 @@
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+      "dev": true
+    },
     "lodash.toarray": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
@@ -5155,10 +5284,36 @@
         "signal-exit": "3.0.2"
       }
     },
+    "lru-cache": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
+      "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=",
+      "dev": true
+    },
     "ltgt": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
       "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
+    },
+    "mailchimp-api-v3": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mailchimp-api-v3/-/mailchimp-api-v3-1.8.0.tgz",
+      "integrity": "sha1-x9LLuB00ILPd5SuYt2G8qdrfd44=",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "lodash": "3.10.1",
+        "request": "2.85.0",
+        "tar": "4.4.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        }
+      }
     },
     "map-obj": {
       "version": "2.0.0",
@@ -5446,6 +5601,25 @@
         "is-plain-obj": "1.1.0"
       }
     },
+    "minipass": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+      "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1",
+        "yallist": "3.0.2"
+      }
+    },
+    "minizlib": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+      "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+      "dev": true,
+      "requires": {
+        "minipass": "2.2.4"
+      }
+    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -5598,6 +5772,12 @@
         "nan": "2.10.0",
         "prebuild-install": "2.5.1"
       }
+    },
+    "nodemailer": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-4.6.4.tgz",
+      "integrity": "sha512-SD4uuX7NMzZ5f5m1XHDd13J4UC3SmdJk8DsmU1g6Nrs5h3x9LcXr6EBPZIqXRJ3LrF7RdklzGhZRF/TuylTcLg==",
+      "dev": true
     },
     "noop-logger": {
       "version": "0.1.1",
@@ -10515,6 +10695,15 @@
         "uuid": "3.2.1"
       }
     },
+    "request-ip": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-2.0.2.tgz",
+      "integrity": "sha1-3urm1K8hdoSX24zQX6NxQ/jxJX4=",
+      "dev": true,
+      "requires": {
+        "is_js": "0.9.0"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -10645,6 +10834,44 @@
       "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.0.0.tgz",
       "integrity": "sha1-nbOE/0uJqPYVY9kjldhiWxjzr7A="
     },
+    "rollbar": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-2.3.9.tgz",
+      "integrity": "sha512-NvZHQDkAYdoYmBtMyUMg5tCYmqeYeOFdOKuWs0opkrLIxj/HU+V9DfEJmKO/FFBnJ7xfEexG4dph8jqkOcRE2g==",
+      "dev": true,
+      "requires": {
+        "async": "1.2.1",
+        "console-polyfill": "0.3.0",
+        "debug": "2.6.9",
+        "decache": "3.1.0",
+        "error-stack-parser": "1.3.3",
+        "extend": "3.0.0",
+        "json-stringify-safe": "5.0.1",
+        "lru-cache": "2.2.4",
+        "request-ip": "2.0.2",
+        "uuid": "3.0.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz",
+          "integrity": "sha1-pIFqF81f9RbfosdpikUzabl5DeA=",
+          "dev": true
+        },
+        "extend": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+          "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+          "dev": true
+        }
+      }
+    },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -10672,6 +10899,15 @@
       "dev": true,
       "requires": {
         "rx-lite": "4.0.8"
+      }
+    },
+    "rxjs": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.8.tgz",
+      "integrity": "sha512-Bz7qou7VAIoGiglJZbzbXa4vpX5BmTTN2Dj/se6+SwADtw4SihqBIiEa7VmTXJ8pynvq0iFr5Gx9VLyye1rIxQ==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
       }
     },
     "safe-buffer": {
@@ -11042,6 +11278,26 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "ssh2": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.5.4.tgz",
+      "integrity": "sha1-G/a2soyW6u8mf01sRqWiUXpZnic=",
+      "dev": true,
+      "requires": {
+        "ssh2-streams": "0.1.20"
+      }
+    },
+    "ssh2-streams": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.1.20.tgz",
+      "integrity": "sha1-URGNFUVV31Rp7h9n4M8efoosDjo=",
+      "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "semver": "5.5.0",
+        "streamsearch": "0.1.2"
+      }
+    },
     "sshpk": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
@@ -11066,6 +11322,12 @@
         "safe-buffer": "5.1.1"
       }
     },
+    "stackframe": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz",
+      "integrity": "sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ=",
+      "dev": true
+    },
     "stream-combiner2": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
@@ -11075,6 +11337,12 @@
         "duplexer2": "0.1.4",
         "readable-stream": "2.3.5"
       }
+    },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
+      "dev": true
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -11178,6 +11446,12 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
+    "symbol-observable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+      "dev": true
+    },
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
@@ -11254,6 +11528,21 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
+      }
+    },
+    "tar": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+      "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
+      "dev": true,
+      "requires": {
+        "chownr": "1.0.1",
+        "fs-minipass": "1.2.5",
+        "minipass": "2.2.4",
+        "minizlib": "1.1.0",
+        "mkdirp": "0.5.1",
+        "safe-buffer": "5.1.1",
+        "yallist": "3.0.2"
       }
     },
     "tar-fs": {
@@ -11344,6 +11633,13 @@
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
       "dev": true
     },
+    "traverse-chain": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/traverse-chain/-/traverse-chain-0.1.0.tgz",
+      "integrity": "sha1-YdvC1Ttp/2CRoSoWj9fUMxB+QPE=",
+      "dev": true,
+      "optional": true
+    },
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -11372,6 +11668,17 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
         "safe-buffer": "5.1.1"
+      }
+    },
+    "tunnel-ssh": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tunnel-ssh/-/tunnel-ssh-4.1.4.tgz",
+      "integrity": "sha512-CjBqboGvAbM7iXSX2F95kzoI+c2J81YkrHbyyo4SWNKCzU6w5LfEvXBCHu6PPriYaNvfhMKzD8bFf5Vl14YTtg==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "lodash.defaults": "4.2.0",
+        "ssh2": "0.5.4"
       }
     },
     "tweetnacl": {
@@ -11606,7 +11913,7 @@
         "ethereumjs-block": "1.7.1",
         "ethereumjs-tx": "1.3.4",
         "ethereumjs-util": "5.1.5",
-        "ethereumjs-vm": "2.3.3",
+        "ethereumjs-vm": "2.3.4",
         "fetch-ponyfill": "4.1.0",
         "json-rpc-error": "2.0.0",
         "json-stable-stringify": "1.0.1",
@@ -11757,6 +12064,12 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yallist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+      "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+      "dev": true
     },
     "yargs": {
       "version": "4.8.1",

--- a/package.json
+++ b/package.json
@@ -47,18 +47,7 @@
     "web3": "^0.20.6",
     "web3-provider-engine": "https://github.com/decentraland/provider-engine.git#releases"
   },
-  "peerDependencies": {
-    "babel-polyfill": "^6.26.0",
-    "commander": "^2.13.0",
-    "dotenv": "^5.0.1",
-    "inquirer": "^5.1.0",
-    "mailchimp-api-v3": "^1.7.1",
-    "mongodb": "^2.2.31",
-    "nodemailer": "^4.1.3",
-    "pg": "^7.3.0",
-    "rollbar": "^2.3.9",
-    "tunnel-ssh": "^4.1.4"
-  },
+  "peerDependencies": {},
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-eslint": "^8.0.1",
@@ -68,17 +57,24 @@
     "babel-preset-env": "^1.6.1",
     "babel-register": "^6.26.0",
     "chai": "^4.1.2",
+    "commander": "^2.13.0",
+    "dotenv": "^5.0.1",
     "eslint": "^4.11.0",
     "eslint-config-prettier": "^2.7.0",
     "eslint-plugin-prettier": "^2.3.1",
     "husky": "^0.14.3",
+    "inquirer": "^5.1.0",
     "jsdoc": "^3.5.5",
+    "mailchimp-api-v3": "^1.7.1",
     "mocha": "^4.0.1",
     "mongodb": "^3.0.5",
+    "nodemailer": "^4.1.3",
     "npx": "^9.7.1",
     "pg": "^7.4.1",
     "prettier": "^1.8.2",
+    "rollbar": "^2.3.9",
     "semantic-release": "^12.2.5",
+    "tunnel-ssh": "^4.1.4",
     "validate-commit-msg": "^2.14.0"
   }
 }


### PR DESCRIPTION
Given that by now all packages using this will have any required dependency installed, it's safe now to move the server-side packages to be devDependencies (deprecating the use of them)